### PR TITLE
Add project planning docs (roadmap + PM requirements)

### DIFF
--- a/docs/PM.md
+++ b/docs/PM.md
@@ -1,0 +1,194 @@
+# Arroz con Code — Product Manager Document
+
+> This document defines the minimum feature requirements each developer must deliver
+> for the product to be considered complete and demo-ready.
+> A feature is not "done" until it meets every criterion listed under it.
+
+---
+
+## Definition of Done — Global Standards
+
+Every feature, regardless of who built it, must meet these before it counts as done:
+
+- Works on both desktop and a small mobile screen (375px wide)
+- All visible text is available in both English and Spanish
+- No broken states — every action either succeeds visibly or shows an error message
+- Merged into the main branch and live on the shared deployment URL
+
+### Auth Model
+
+- **No login required:** Browse the community board, read posts, read comments, use the AI Chat
+- **Login required:** Create a post, submit a comment
+- Unauthenticated users are never blocked from viewing content — only from contributing
+
+---
+
+## Feature 1: User Authentication
+
+**Owner:** D2 (backend), D1 (UI)
+
+### Minimum to be done:
+
+- [ ] A new user can create an account using an email address and password
+- [ ] A returning user can sign in with their email and password
+- [ ] A signed-in user stays logged in across page refreshes
+- [ ] A signed-in user can sign out
+- [ ] Only actions that require login (create post, submit comment) redirect unauthenticated users to sign in — all other pages are accessible without an account
+- [ ] If sign-in fails (wrong password, unregistered email), the user sees a clear error message in their language
+
+### Out of scope for done:
+
+- Password reset flow
+- Social login (Google, etc.)
+- Email verification
+
+---
+
+## Feature 2: AI Chat
+
+**Owner:** D3 (API + prompt), D1 (UI integration)
+
+### Minimum to be done:
+
+- [ ] Any visitor (signed in or not) can use the AI Chat — no login required
+- [ ] The AI responds in the same language the user wrote in (Spanish or English)
+- [ ] The AI only answers questions related to Education, Healthcare, or New Tech — it politely declines anything else
+- [ ] The AI response streams in progressively (user sees words appear, not a loading spinner then a wall of text)
+- [ ] If the AI fails or times out, the user sees a friendly error message — the app does not crash or show a blank screen
+- [ ] The user can give a thumbs up or thumbs down on any AI response
+
+### Out of scope for done:
+
+- Chat history saved across sessions
+- AI citing specific URLs (nice to have but not required)
+- Voice input
+
+---
+
+## Feature 3: Community Board — Post List
+
+**Owner:** D4 (backend + UI)
+
+### Minimum to be done:
+
+- [ ] Any visitor (signed in or not) can view the community board
+- [ ] Posts are displayed with: title, category label, author display name, and time posted
+- [ ] Posts are grouped or filterable by the three categories: Education, Healthcare, New Tech
+- [ ] Selecting a category shows only posts in that category
+- [ ] The board updates without a full page reload when a new post is added (or on refresh at minimum)
+- [ ] If there are no posts in a category, a friendly empty state is shown (not a blank page)
+
+### Out of scope for done:
+
+- Keyword search
+- Sorting (newest, most upvoted)
+- Pagination (showing all posts is fine for demo)
+
+---
+
+## Feature 4: Community Board — Create Post
+
+**Owner:** D4 (backend + UI)
+
+### Minimum to be done:
+
+- [ ] A signed-in user can create a post with: a title, a body (text), and a category selection
+- [ ] The category field is required — the form does not submit without one selected
+- [ ] After submitting, the user is taken to the new post's detail page (or the board refreshes showing the post)
+- [ ] A guest who tries to create a post is redirected to sign in, then returned to the board after logging in
+- [ ] If the post fails to save, the user sees an error and their text is not lost
+
+### Out of scope for done:
+
+- Image uploads
+- Tags beyond the 3 main categories
+- Rich text / markdown formatting
+
+---
+
+## Feature 5: Community Board — Post Detail & Comments
+
+**Owner:** D4 (backend + UI)
+
+### Minimum to be done:
+
+- [ ] Any visitor can open a post and read the full title, body, author, and timestamp
+- [ ] Any visitor can read all comments, displayed in chronological order
+- [ ] A signed-in user can submit a comment — it appears on the page immediately after submitting
+- [ ] A guest who tries to comment is prompted to sign in (inline prompt or redirect), then returned to the post
+- [ ] A signed-in user can delete their own comments (not others')
+- [ ] If a comment fails to post, the user sees an error
+
+### Out of scope for done:
+
+- Threaded/nested replies
+- Comment editing
+- Upvotes (should-have, not must-have)
+
+---
+
+## Feature 6: Bilingual UI (i18n)
+
+**Owner:** D1
+
+### Minimum to be done:
+
+- [ ] A language toggle is visible and accessible from every page (navbar or header)
+- [ ] Switching language immediately updates all UI text on the current page without a full reload
+- [ ] All of the following are translated in both English and Spanish:
+  - Navigation items and buttons
+  - Landing page headline and CTAs
+  - Auth form labels, placeholders, and error messages
+  - Chat page labels and placeholder text
+  - Community board category names, empty states, and button labels
+  - Post creation form labels and validation errors
+  - Comment form labels
+- [ ] The AI chat responds in the language the user types in (not controlled by the toggle — the AI detects it)
+
+### Out of scope for done:
+
+- User language preference saved to their profile
+- Any language beyond Spanish and English
+
+---
+
+## Feature 7: Landing Page
+
+**Owner:** D1
+
+### Minimum to be done:
+
+- [ ] The page clearly communicates what the product does in one headline (in the current language)
+- [ ] There are two clear calls-to-action: one that goes to the AI Chat, one that goes to the Community Board
+- [ ] A signed-in user sees their name or a sign-out option in the navbar
+- [ ] A signed-out user sees sign-in and sign-up links in the navbar
+- [ ] The page looks intentional and readable on mobile
+
+### Out of scope for done:
+
+- Marketing copy beyond the headline and CTAs
+- Animation or illustrations
+- Footer links
+
+---
+
+## Acceptance Criteria Summary
+
+| Feature                       | Who Signs Off | Hard Requirement?      |
+| ----------------------------- | ------------- | ---------------------- |
+| User Authentication           | D2 + D1       | Yes — gates all else   |
+| AI Chat                       | D3 + D1       | Yes — core feature     |
+| Community Board — Post List   | D4            | Yes — core feature     |
+| Community Board — Create Post | D4            | Yes — core feature     |
+| Post Detail & Comments        | D4            | Yes — core feature     |
+| Bilingual UI                  | D1            | Yes — differentiator   |
+| Landing Page                  | D1            | Yes — demo entry point |
+
+---
+
+## How to Use This Document
+
+- Before calling a feature done, the developer checks every box under that feature
+- If a checkbox cannot be completed in time, it is flagged to the team — not silently dropped
+- The PM reviews each feature against this list before the demo build is locked
+- Anything not in this document is a stretch goal — don't spend time on it until all boxes above are checked

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,149 @@
+# Arroz con Code — Project Plan
+
+> Web app helping Hispanic communities access education, healthcare, and new tech
+> through an AI Chat and a Community Board.
+> **Total time: 12 hours | 4 developers**
+
+---
+
+## Business Requirements Checklist
+
+### Must-Have (MVP — demo must show these)
+
+- [ ] Bilingual UI — Spanish / English toggle
+- [ ] User auth: sign up and sign in with email
+- [ ] AI Chat: ask a question, get a bilingual response (Education, Healthcare, New Tech)
+- [ ] Community Board: create a post, pick a category, others can comment
+- [ ] Basic responsive layout (works on mobile)
+
+### Should-Have (if time allows)
+
+- [ ] Upvote posts and comments
+- [ ] Filter community board by category
+- [ ] AI chat history saved per session
+- [ ] Profile page with display name and avatar
+
+### Won't-Do (cut for 12 hours)
+
+- ~~Social OAuth (Google, etc.)~~ — email-only auth is enough to demo
+- ~~Moderator dashboard~~ — no time
+- ~~Auto-moderation / profanity filter~~ — out of scope
+- ~~Email notifications / follow post~~ — out of scope
+- ~~Search~~ — category filter covers demo needs
+- ~~PWA / offline mode~~ — post-hackathon stretch goal
+
+---
+
+## Developer Roles
+
+| Dev | Role               | Owns                                                       |
+| --- | ------------------ | ---------------------------------------------------------- |
+| D1  | Frontend / UI Lead | Layout, all pages, i18n strings, responsive polish         |
+| D2  | Backend / API Lead | Database schema, auth, API routes, data queries            |
+| D3  | AI Integration     | AI chat API route, chat UI, system prompt, streaming       |
+| D4  | Community Features | Community board UI + API, posts, comments, category filter |
+
+---
+
+## 12-Hour Roadmap
+
+### Hour 0–1: Setup (All Devs Together)
+
+**Goal:** Everyone has the app running locally and can push code.
+
+- [ ] **All** — Agree on Git workflow: `main` is always deployable, feature branches per dev
+- [ ] **D1** — Scaffold frontend project, set up component library, set up i18n (ES/EN stubs)
+- [ ] **D2** — Set up database, define schema (users, posts, comments, chat feedback), share environment config with team
+- [ ] **D3** — Get AI API key, create chat endpoint stub, confirm it returns a response
+- [ ] **D4** — Confirm posts/comments tables are live, test a manual insert
+- [ ] **All** — Deploy skeleton to hosting platform, confirm preview URL works
+
+---
+
+### Hours 1–5: Core Build (Parallel — each dev on their lane)
+
+#### D1 — Pages & Layout
+
+- [ ] App shell: navbar (logo, language toggle, login/signup link), main content area
+- [ ] Landing page: headline, 2 CTA buttons ("Ask AI" and "Join Community")
+- [ ] Auth pages: sign up / sign in forms
+- [ ] Chat page: message thread, input box, send button, loading state
+- [ ] Community board page: list of posts, category tabs, "New Post" button
+
+#### D2 — Auth & API
+
+- [ ] Email sign up + sign in, session handling
+- [ ] Only create post and submit comment actions require login — viewing board, posts, and AI chat is open to all
+- [ ] List posts endpoint (with category filter), create post endpoint
+- [ ] Get comments for a post, add comment endpoint
+- [ ] Get and update current user profile endpoint
+- [ ] Users can only edit/delete their own content (authorization rules)
+
+#### D3 — AI Chat
+
+- [ ] Write system prompt:
+  - Role: bilingual assistant for Hispanic communities
+  - Topics: education, healthcare, new tech only — decline off-topic questions politely
+  - Language: match the language of the user's message
+  - Tone: warm, clear, community-oriented
+- [ ] Chat endpoint: accept message + language preference, stream AI response
+- [ ] Connect chat UI to endpoint with streaming
+- [ ] Thumbs up/down button — save feedback to database
+
+#### D4 — Community Board
+
+- [ ] Fetch and display posts, grouped/filterable by category
+- [ ] Create post form: title, body, category (Education / Healthcare / New Tech)
+- [ ] Post detail page: show post + comments, comment input
+- [ ] Submit comment with optimistic UI update
+
+---
+
+### Hours 5–9: Integration & Secondary Features
+
+- [ ] **D1 + D3** — Chat page fully works with real streaming AI responses
+- [ ] **D1 + D4** — Community board create/read/comment fully works end-to-end
+- [ ] **D2** — Add upvote endpoint if time allows; otherwise skip
+- [ ] **D3** — Inject curated resource links per topic into AI system prompt (5–10 links each)
+- [ ] **D4** — Category filter tabs wire up to actual API query
+- [ ] **D1** — Finish all i18n strings for every visible page (ES + EN)
+- [ ] **All** — Fix blockers from integration, merge feature branches to main
+
+---
+
+### Hours 9–11: Polish & QA
+
+- [ ] **D1** — Mobile responsive check: navbar, chat, community board all usable on small screens
+- [ ] **D1** — Loading states for feed and chat responses
+- [ ] **D2** — Verify all protected routes redirect unauthenticated users
+- [ ] **D3** — Test AI in Spanish and English, tune prompt if responses feel off
+- [ ] **D4** — End-to-end QA: sign up → create post → comment → switch language → ask AI
+- [ ] **All** — Seed database: 3–5 sample posts per category in Spanish and English
+
+---
+
+### Hours 11–12: Demo Prep
+
+- [ ] **All** — Final production deploy, confirm all environment variables are set
+- [ ] **D1** — Prepare demo flow (browser tab open, logged-in test account ready):
+  1. Land on homepage
+  2. Switch language to Spanish
+  3. Click "Ask AI" → ask a healthcare question in Spanish → get response
+  4. Click "Join Community" → show board → open a post → leave a comment
+  5. Create a new post
+- [ ] **All** — 2-minute pitch outline:
+  - **Problem:** Hispanic communities face language and access barriers for education/healthcare/tech info
+  - **Solution:** AI chat in their language + a community of people who've been there
+  - **Demo:** live walkthrough
+  - **Impact:** what this could mean at scale
+
+---
+
+## Key Integration Risks
+
+| Risk                           | Mitigation                                                  |
+| ------------------------------ | ----------------------------------------------------------- |
+| Database setup takes too long  | D2 owns this solo in Hour 0, unblocks everyone by Hour 1    |
+| AI API key not working         | D3 tests in Hour 0, uses a mock response for dev mode       |
+| i18n slows D1 down             | Hardcode English first, add Spanish strings in Hours 9–11   |
+| Auth bugs block community work | D4 can build community UI with a hardcoded test user in dev |


### PR DESCRIPTION
## Summary                                                                                                                                                                     
  - Adds `docs/ROADMAP.md` — 12-hour hackathon timeline, 4 developer roles, and hourly task breakdown                                                                            
  - Adds `docs/PM.md` — feature-by-feature requirements with minimum definition of done for each     
  - Establishes auth model: viewing and AI chat are open to all, login only required to post or comment 
  
  ## Why                                                                                                                                                                         
  Gives the team a shared source of truth before any code is written — scope is locked, responsibilities are clear, and the PM doc removes ambiguity around what "done" means for each feature.   